### PR TITLE
Applied fix for fatal bug in 2D histogram generation

### DIFF
--- a/SMBJClassifier/model.py
+++ b/SMBJClassifier/model.py
@@ -166,6 +166,7 @@ def generate_2d_histogram(data, RR, d, inputName, para,
         D = []
         for j in range(sampleNum): 
             cond = cond_train[idx[j]]
+            cond = np.squeeze(np.array([c[1:] for c in cond]))
             dist = dist_train[idx[j]]
             G = np.append(G, cond)
             D = np.append(D, dist)
@@ -183,6 +184,7 @@ def generate_2d_histogram(data, RR, d, inputName, para,
         D = []
         for j in range(sampleNum): 
             cond = cond_test[idx[j]]
+            cond = np.squeeze(np.array([c[1:] for c in cond]))
             dist = dist_test[idx[j]]
             G = np.append(G, cond)
             D = np.append(D, dist)


### PR DESCRIPTION
I applied a fix for a fatal bug in the 2D histogram generation.

Previously, the `cond` variable had a second dimension which would always contain two elements. The first of these elements was redundant - it always had the same value. This added nothing of value to the data for the ML model to learn. The second element was the actual conductance values. This issue gave the `cond` array a different dimensionality than the `dist` array, meaning they were not compatible to create a 2D histogram. This resulted in a fatal bug when using `np.histogram2D`.

My code resolves this by removing the redundant elements and applying `np.squeeze` to revert the array to be 1-dimensional. This allows `np.histogram2D` to be run with no error messages. The new line is below:
```python
cond = np.squeeze(np.array([c[1:] for c in cond]))
```